### PR TITLE
Add autobuilds for version tags

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,0 +1,66 @@
+name: Build and push OCI image to Docker Hub
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  check-current-branch:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.check_step.outputs.branch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get current branch
+        id: check_step
+        # 1. Get the list of branches ref where this tag exists
+        # 2. Remove 'origin/' from that result
+        # 3. Put that string in output
+        run: |
+          raw=$(git branch -r --contains ${{ github.ref }})
+          branch="$(echo ${raw//origin\//} | tr -d '\n')"
+          echo "{name}=branch" >> $GITHUB_OUTPUT
+          echo "Branches where this tag exists : $branch."
+
+  image:
+    runs-on: ubuntu-latest
+    needs: check-current-branch
+    if: contains(${{ needs.check.outputs.branch }}, 'main')`
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Get build args
+        id: build_args
+        run: |
+          echo "APP_COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "APP_VERSION=$(git describe --tags --always --abbrev=0 --match='v[0-9]*.[0-9]*.[0-9]*' 2> /dev/null | sed 's/^.//')" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: bsvb/message-box-server
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_COMMIT=${{ steps.build_args.outputs.APP_COMMIT }}
+            APP_VERSION=${{ steps.build_args.outputs.APP_VERSION }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the building and publishing of an OCI (Open Container Initiative) image to Docker Hub when a new tag is pushed. Below are the key changes:

### New GitHub Actions Workflow:

* **Workflow Name**: Added a new workflow file `.github/workflows/image.yaml` to handle the build and push process for OCI images.

* **Trigger**: Configured the workflow to trigger on `push` events for tags matching the pattern `v*`.

* **Branch Validation**: Introduced a `check-current-branch` job to determine if the tag exists on the `main` branch. This ensures the workflow proceeds only when the tagged commit is on the `main` branch.

* **Docker Image Build and Push**: Added an `image` job to:
  - Retrieve build arguments such as `APP_COMMIT` and `APP_VERSION` from the repository.
  - Log in to Docker Hub using credentials stored in GitHub Secrets.
  - Use `docker/metadata-action` to generate image tags and labels.
  - Build and push the Docker image to the `bsvb/message-box-server` repository on Docker Hub.